### PR TITLE
[FIX] registry: init_models() using a closed cursor

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -292,6 +292,9 @@ class Registry(Mapping):
         env = odoo.api.Environment(cr, SUPERUSER_ID, context)
         models = [env[model_name] for model_name in model_names]
 
+        # make sure the queue does not contain some leftover from a former call
+        self._post_init_queue.clear()
+
         for model in models:
             model._auto_init()
             model.init()


### PR DESCRIPTION
When a call to init_models() fails, the post-init queue still contains
callables that refer to a soon-to-be-closed cursor.  If one calls
init_models() in another request, the post-init process will inevitably
fail because it refers to closed cursors.

closes odoo/odoo#40369

X-original-commit: 33f87ffebaa1cb38e3ce8ce44c8b8b538b49e5b9
Signed-off-by: Raphael Collet (rco) <rco@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
